### PR TITLE
Fix vertex strides issues and a device memory leak

### DIFF
--- a/Rosella/src/main/java/me/hydos/rosella/memory/buffer/GlobalBufferManager.java
+++ b/Rosella/src/main/java/me/hydos/rosella/memory/buffer/GlobalBufferManager.java
@@ -46,7 +46,7 @@ public class GlobalBufferManager {
 
     public void nextFrame(Set<RenderInfo> renderObjects) {
         if (isFrameDifferent(lastRenderObjects, renderObjects)) {
-            if(this.vertexBuffer != null) {
+            if(this.vertexBuffer != null) { // TODO: Dont forget to properly refractory this at some point
                 memory.freeBuffer(this.vertexBuffer);
             }
             if(this.indexBuffer != null) {

--- a/Rosella/src/main/java/me/hydos/rosella/memory/buffer/GlobalBufferManager.java
+++ b/Rosella/src/main/java/me/hydos/rosella/memory/buffer/GlobalBufferManager.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import static org.lwjgl.system.MemoryStack.stackPush;
 import static org.lwjgl.util.vma.Vma.VMA_MEMORY_USAGE_CPU_TO_GPU;
+import static org.lwjgl.util.vma.Vma.VMA_MEMORY_USAGE_GPU_ONLY;
 import static org.lwjgl.vulkan.VK10.*;
 
 /**
@@ -45,6 +46,12 @@ public class GlobalBufferManager {
 
     public void nextFrame(Set<RenderInfo> renderObjects) {
         if (isFrameDifferent(lastRenderObjects, renderObjects)) {
+            if(this.vertexBuffer != null) {
+                memory.freeBuffer(this.vertexBuffer);
+            }
+            if(this.indexBuffer != null) {
+                memory.freeBuffer(this.indexBuffer);
+            }
             this.vertexBuffer = createVertexBuffer(renderObjects);
             this.indexBuffer = createIndexBuffer(renderObjects);
         }
@@ -155,7 +162,7 @@ public class GlobalBufferManager {
             BufferInfo vertexBuffer = memory.createBuffer(
                     finalTotalSize,
                     VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
-                    VMA_MEMORY_USAGE_CPU_TO_GPU,
+                    VMA_MEMORY_USAGE_GPU_ONLY,
                     pBuffer
             );
 

--- a/Rosella/src/main/java/me/hydos/rosella/memory/buffer/GlobalBufferManager.java
+++ b/Rosella/src/main/java/me/hydos/rosella/memory/buffer/GlobalBufferManager.java
@@ -36,6 +36,7 @@ public class GlobalBufferManager {
 
     public final Object2IntMap<RenderInfo> indicesOffsetMap = new Object2IntOpenHashMap<>();
     public final Object2IntMap<RenderInfo> vertexOffsetMap = new Object2IntOpenHashMap<>();
+    public final Object2IntMap<RenderInfo> bufferOffsetMap = new Object2IntOpenHashMap<>();
 
     public GlobalBufferManager(Rosella rosella) {
         this.memory = rosella.common.memory;
@@ -126,6 +127,7 @@ public class GlobalBufferManager {
                 int bufferOffset = 0;
                 for (RenderInfo renderInfo : renderList) {
                     vertexOffsetMap.put(renderInfo, vertexOffset);
+                    bufferOffsetMap.put(renderInfo, bufferOffset);
                     for(BufferProvider.ManagedBuffer src : renderInfo.bufferProvider.getBuffers()) {
                         dst.put(bufferOffset + src.dstPos(), src.buffer(), src.srcPos(), src.length());
                     }

--- a/Rosella/src/main/java/me/hydos/rosella/render/renderer/Renderer.java
+++ b/Rosella/src/main/java/me/hydos/rosella/render/renderer/Renderer.java
@@ -351,13 +351,17 @@ public class Renderer {
                     bindBigBuffers(rosella.bufferManager, stack, commandBuffer);
                     for (RenderInfo renderInfo : simpleObjectManager.renderObjects.keySet()) {
                         for (InstanceInfo instance : simpleObjectManager.renderObjects.get(renderInfo)) {//rosella.bufferManager.vertexOffsetMap.get(renderInfo)
+                            LongBuffer offsets = stack.longs(rosella.bufferManager.bufferOffsetMap.getInt(renderInfo));
+                            LongBuffer vertexBuffers = stack.longs(rosella.bufferManager.vertexBuffer.buffer());
+                            vkCmdBindVertexBuffers(commandBuffer, 0, vertexBuffers, offsets);
+
                             bindInstanceInfo(instance, stack, commandBuffer, i);
                             vkCmdDrawIndexed(
                                     commandBuffer,
                                     renderInfo.getIndicesSize(),
                                     1,
                                     rosella.bufferManager.indicesOffsetMap.getInt(renderInfo),
-                                    rosella.bufferManager.vertexOffsetMap.getInt(renderInfo),
+                                    /*rosella.bufferManager.vertexOffsetMap.getInt(renderInfo)*/ 0,
                                     0
                             );
                         }

--- a/Rosella/src/main/java/me/hydos/rosella/render/renderer/Renderer.java
+++ b/Rosella/src/main/java/me/hydos/rosella/render/renderer/Renderer.java
@@ -350,18 +350,14 @@ public class Renderer {
                 if (rosella.bufferManager != null && !simpleObjectManager.renderObjects.isEmpty()) {
                     bindBigBuffers(rosella.bufferManager, stack, commandBuffer);
                     for (RenderInfo renderInfo : simpleObjectManager.renderObjects.keySet()) {
-                        for (InstanceInfo instance : simpleObjectManager.renderObjects.get(renderInfo)) {//rosella.bufferManager.vertexOffsetMap.get(renderInfo)
-                            LongBuffer offsets = stack.longs(rosella.bufferManager.bufferOffsetMap.getInt(renderInfo));
-                            LongBuffer vertexBuffers = stack.longs(rosella.bufferManager.vertexBuffer.buffer());
-                            vkCmdBindVertexBuffers(commandBuffer, 0, vertexBuffers, offsets);
-
+                        for (InstanceInfo instance : simpleObjectManager.renderObjects.get(renderInfo)) {
                             bindInstanceInfo(instance, stack, commandBuffer, i);
                             vkCmdDrawIndexed(
                                     commandBuffer,
                                     renderInfo.getIndicesSize(),
                                     1,
                                     rosella.bufferManager.indicesOffsetMap.getInt(renderInfo),
-                                    /*rosella.bufferManager.vertexOffsetMap.getInt(renderInfo)*/ 0,
+                                    rosella.bufferManager.vertexOffsetMap.getInt(renderInfo),
                                     0
                             );
                         }

--- a/Rosella/src/main/java/me/hydos/rosella/render/vertex/VertexFormat.java
+++ b/Rosella/src/main/java/me/hydos/rosella/render/vertex/VertexFormat.java
@@ -4,7 +4,7 @@ import org.lwjgl.vulkan.VK10;
 import org.lwjgl.vulkan.VkVertexInputAttributeDescription;
 import org.lwjgl.vulkan.VkVertexInputBindingDescription;
 
-public class  VertexFormat {
+public class VertexFormat {
     private final VertexFormatElement[] elements;
     private final VkVertexInputAttributeDescription.Buffer vkAttributes;
     private final VkVertexInputBindingDescription.Buffer vkBindings;
@@ -18,7 +18,7 @@ public class  VertexFormat {
         int offset = 0;
         for (int idx = 0; idx < elements.length; idx++) {
             VertexFormatElement element = elements[idx];
-            if (element.vkType() != VertexFormatElements.VK_FORMAT_PADDING) { // TODO: You have an empty attribute here if you have padding
+            if (element.vkType() != VertexFormatElements.VK_FORMAT_PADDING) {
                 vkAttributes.get(idx)
                         .binding(0)
                         .location(idx)

--- a/Rosella/src/main/java/me/hydos/rosella/render/vertex/VertexFormat.java
+++ b/Rosella/src/main/java/me/hydos/rosella/render/vertex/VertexFormat.java
@@ -4,7 +4,7 @@ import org.lwjgl.vulkan.VK10;
 import org.lwjgl.vulkan.VkVertexInputAttributeDescription;
 import org.lwjgl.vulkan.VkVertexInputBindingDescription;
 
-public class VertexFormat {
+public class  VertexFormat {
     private final VertexFormatElement[] elements;
     private final VkVertexInputAttributeDescription.Buffer vkAttributes;
     private final VkVertexInputBindingDescription.Buffer vkBindings;
@@ -18,7 +18,7 @@ public class VertexFormat {
         int offset = 0;
         for (int idx = 0; idx < elements.length; idx++) {
             VertexFormatElement element = elements[idx];
-            if (element.vkType() != VertexFormatElements.VK_FORMAT_PADDING) {
+            if (element.vkType() != VertexFormatElements.VK_FORMAT_PADDING) { // TODO: You have an empty attribute here if you have padding
                 vkAttributes.get(idx)
                         .binding(0)
                         .location(idx)

--- a/src/main/java/me/hydos/blaze4d/mixin/texture/RenderSystemMixin.java
+++ b/src/main/java/me/hydos/blaze4d/mixin/texture/RenderSystemMixin.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(RenderSystem.class)
 public class RenderSystemMixin {
 
-    @Inject(method = "setShaderTexture(ILnet/minecraft/util/Identifier;)V", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "setShaderTexture(ILnet/minecraft/util/Identifier;)V", remap = false, at = @At("HEAD"), cancellable = true)
     private static void setTextureFromIdentifier(int i, Identifier identifier, CallbackInfo ci) {
         if (i >= 0 && i < GlobalRenderSystem.boundTextureIds.length) {
             TextureManager textureManager = MinecraftClient.getInstance().getTextureManager();
@@ -26,7 +26,7 @@ public class RenderSystemMixin {
     }
 
 
-    @Inject(method = "setShaderTexture(II)V", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "setShaderTexture(II)V", at = @At("HEAD"), remap = false, cancellable = true)
     private static void setTextureFromId(int i, int j, CallbackInfo ci) {
         if (i >= 0 && i < GlobalRenderSystem.boundTextureIds.length) {
             GlobalRenderSystem.boundTextureIds[i] = j;
@@ -34,7 +34,7 @@ public class RenderSystemMixin {
         ci.cancel();
     }
 
-    @Inject(method = "getShaderTexture", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "getShaderTexture", at = @At("HEAD"), remap = false, cancellable = true)
     private static void getTextureFromUs(int i, CallbackInfoReturnable<Integer> cir) {
         cir.setReturnValue(i >= 0 && i < GlobalRenderSystem.boundTextureIds.length ? GlobalRenderSystem.boundTextureIds[i] : 0);
     }


### PR DESCRIPTION
So i fixed the vertex strides issues by rebinding the main buffer before each draw call with a byte offset. It is an ugly hack but honestly im not sure if it is possible to do this cleanly without some refractors. 

Also the RenderSystemMixin required the `remap = false` otherwise it would not build for me.