### PR TITLE
Add semaphore pool

### DIFF
--- a/Rosella/src/main/java/me/hydos/rosella/Rosella.java
+++ b/Rosella/src/main/java/me/hydos/rosella/Rosella.java
@@ -10,6 +10,7 @@ import me.hydos.rosella.memory.buffer.GlobalBufferManager;
 import me.hydos.rosella.render.renderer.Renderer;
 import me.hydos.rosella.scene.object.ObjectManager;
 import me.hydos.rosella.scene.object.impl.SimpleObjectManager;
+import me.hydos.rosella.util.SemaphorePool;
 import me.hydos.rosella.vkobjects.VkCommon;
 import me.hydos.rosella.vkobjects.VulkanInstance;
 import org.apache.logging.log4j.Level;
@@ -61,6 +62,7 @@ public class Rosella {
         common.device = new VulkanDevice(common, requestedValidationLayers);
         common.queues = new VulkanQueues(common);
         common.memory = new ThreadPoolMemory(common);
+        common.semaphorePool = new SemaphorePool(common.device.rawDevice);
 
         // Setup the object manager
         this.objectManager = new SimpleObjectManager(this, common);
@@ -83,6 +85,7 @@ public class Rosella {
 
         // Free the rest of it
         common.memory.free();
+        common.semaphorePool.free();
 
         vkDestroyCommandPool(common.device.rawDevice, renderer.commandPool, null);
         vkDestroyDevice(common.device.rawDevice, null);

--- a/Rosella/src/main/java/me/hydos/rosella/util/SemaphorePool.java
+++ b/Rosella/src/main/java/me/hydos/rosella/util/SemaphorePool.java
@@ -1,0 +1,98 @@
+package me.hydos.rosella.util;
+
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.vulkan.VK10;
+import org.lwjgl.vulkan.VkDevice;
+import org.lwjgl.vulkan.VkSemaphoreCreateInfo;
+
+import java.nio.LongBuffer;
+import java.util.Set;
+import java.util.Stack;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class SemaphorePool {
+
+    private static final int ALLOCATION_SIZE = 16;
+
+    private final VkDevice device;
+
+    private final Set<Long> ownedSemaphores = new LongOpenHashSet();
+    private final Stack<Long> availableSemaphores = new Stack<>();
+
+    private final Lock lock = new ReentrantLock();
+
+    public SemaphorePool(VkDevice device) {
+        this.device = device;
+    }
+
+    public long getSemaphore() {
+        long result;
+        try {
+            lock();
+            if(availableSemaphores.isEmpty()) {
+                allocateSemaphores(ALLOCATION_SIZE);
+            }
+            result = availableSemaphores.pop();
+        } finally {
+           unlock();
+        }
+        return result;
+    }
+
+    public void returnSemaphore(long semaphore) {
+        try {
+            lock();
+            if(!ownedSemaphores.contains(semaphore)) {
+                throw new RuntimeException("Tried to return semaphore to semaphore pool that is not owned by the pool");
+            }
+            availableSemaphores.push(semaphore);
+        } finally {
+            unlock();
+        }
+    }
+
+    public void destroy() {
+        try{
+            lock();
+            if(this.ownedSemaphores.size() != this.availableSemaphores.size()) {
+                throw new RuntimeException("Tried to destroy semaphore pool where not all semaphores are returned");
+            }
+
+            for(long semaphore : ownedSemaphores) {
+                VK10.vkDestroySemaphore(this.device, semaphore, null);
+            }
+            this.ownedSemaphores.clear();
+            this.availableSemaphores.clear();
+        } finally {
+            unlock();
+        }
+    }
+
+    private void allocateSemaphores(int count) {
+        try (MemoryStack stack = MemoryStack.stackPush()) {
+            VkSemaphoreCreateInfo info = VkSemaphoreCreateInfo.callocStack(stack);
+            info.sType(VK10.VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO);
+
+            LongBuffer pSemaphore = stack.longs(0);
+            for(int i = 0; i < count; i++) {
+                int result = VK10.vkCreateSemaphore(device, info, null, pSemaphore);
+                if(result != VK10.VK_SUCCESS) {
+                    throw new RuntimeException("Failed to allocate semaphores");
+                }
+
+                this.ownedSemaphores.add(pSemaphore.get());
+                this.availableSemaphores.push(pSemaphore.get());
+            }
+        }
+    }
+
+    private void lock() {
+        this.lock.lock();
+    }
+
+    private void unlock() {
+        this.lock.unlock();
+    }
+}

--- a/Rosella/src/main/java/me/hydos/rosella/util/SemaphorePool.java
+++ b/Rosella/src/main/java/me/hydos/rosella/util/SemaphorePool.java
@@ -53,7 +53,7 @@ public class SemaphorePool {
         }
     }
 
-    public void destroy() {
+    public void free() {
         try{
             lock();
             if(this.ownedSemaphores.size() != this.availableSemaphores.size()) {

--- a/Rosella/src/main/java/me/hydos/rosella/vkobjects/VkCommon.java
+++ b/Rosella/src/main/java/me/hydos/rosella/vkobjects/VkCommon.java
@@ -4,6 +4,7 @@ import me.hydos.rosella.device.VulkanDevice;
 import me.hydos.rosella.device.VulkanQueues;
 import me.hydos.rosella.display.Display;
 import me.hydos.rosella.memory.Memory;
+import me.hydos.rosella.util.SemaphorePool;
 
 /**
  * Common fields shared within the {@link me.hydos.rosella.Rosella} instance. sharing this info with other instances of the engine is extremely unsafe.
@@ -14,6 +15,11 @@ public class VkCommon {
      * Access to the memory allocator to be used for Vulkan
      */
     public Memory memory;
+
+    /**
+     * Semaphore pool utility
+     */
+    public SemaphorePool semaphorePool;
 
     /**
      * The display used to display the window.


### PR DESCRIPTION
This is just a small utility class providing a semaphore pool. The idea is that any time some operation requires a semaphore it can get one from the pool and then return it after the operation has completed. (for example using a fence and asynchronous callback or some other way). The benefit is that the user doesn't have to worry about ensuring that the operation has completed before resubmitting the semaphore again which can be a headache when you use locally owned semaphores.