### PR TITLE
Add support for building Rosella in-tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ bin/
 
 run/
 
+# Ignore rosella if it's being modified at the same time
+/Rosella
+
 # random log files
 *.log
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ We have a [Discord server](https://discord.gg/H93wJePuWf) where you can track de
 1. Clone the repository (https://github.com/Blaze4D-MC/Blaze4D.git)
 2. Run ``gradlew build`` in the project folder.
 
+Optionally, clone Rosella (https://github.com/KilnGraphics/Rosella) into the project folder, and
+it will be used instead of the copy from Maven.
+
 ## Contributing
 1. Clone the Repository
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,12 @@ val lwjglNatives = when (OperatingSystem.current()) {
 	else -> throw Error("Unrecognized or unsupported Operating system. Please set \"lwjglNatives\" manually")
 }
 
+// If we're building Rosella in-tree, look that project up here
+// The idea here is that you can clone a copy of Rosella into the project directly and settings.gradle.kts will
+// find it and load it as a subproject. With this we can make it easy to work on both at once, being able to
+// modify and debug across both projects without having to manually publish to maven local.
+val rosellaProject = subprojects.firstOrNull { it.path == ":rosella" }
+
 repositories {
 	mavenCentral()
 
@@ -55,7 +61,14 @@ dependencies {
 	modImplementation("net.fabricmc", "fabric-loader", properties["loader_version"].toString())
 	modImplementation("net.fabricmc", "fabric-language-kotlin", "1.6.4+kotlin.1.5.30")
 
-	include(implementation("graphics.kiln", "rosella", "1.2.0-SNAPSHOT"))
+	// If we're building Rosella as part of the project for debugging, use that
+	// Otherwise, fetch it from Maven
+	if (rosellaProject != null) {
+		implementation(rosellaProject)
+	} else {
+		include(implementation("graphics.kiln", "rosella", "1.2.0-SNAPSHOT"))
+	}
+
 	include(implementation("com.oroarmor", "aftermath", "1.0.0-beta"))
 
 	include(implementation("org.joml", "joml", "1.10.1"))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,3 +13,10 @@ pluginManagement {
         }
     }
 }
+
+// If the user is running an in-tree copy of Rosella, add that as a sub-project
+val rosellaDir = File("Rosella")
+if (rosellaDir.exists()) {
+    include(":rosella")
+    project(":rosella").projectDir = rosellaDir
+}


### PR DESCRIPTION
As per the commit message:

This patch adds support for building Rosella as a gradle subproject.

This is convenient if you're working on Rosella at the same time as
Blaze4D: you can edit both projects inside a single copy of IDEA, and
even hot-reload Rosella changes in a running instance of Minecraft.